### PR TITLE
Add support for passive/active frames

### DIFF
--- a/src/Animation.hpp
+++ b/src/Animation.hpp
@@ -24,7 +24,6 @@ class Animation
     private:
         bool valid_animation = false;
         int current_frame_number = 0;
-        int total_frames_number = 0;
         int total_frames_files = 0;
         GLuint* frames = NULL;
         uint8_t** frames_pixels = NULL;
@@ -32,8 +31,12 @@ class Animation
         std::vector<int> frames_order;
         std::chrono::system_clock::time_point time_at_last_frame;
 
+        uint passive_frames = 0;
+        uint active_frames = 0;
+
     public:
         bool selected = false;
+        bool active = false;
 
         int min_butthurt = 0;
         int max_butthurt = 14;

--- a/src/AnimationWallet.cpp
+++ b/src/AnimationWallet.cpp
@@ -186,3 +186,9 @@ void AnimationWallet::replace_min_max_butthurt(int new_min_butthurt, int new_max
         anim->max_butthurt = new_max_butthurt;
     }
 }
+
+void AnimationWallet::set_active(bool active)
+{
+    for(Animation* anim : this->animations)
+        anim->active = active;
+}

--- a/src/AnimationWallet.hpp
+++ b/src/AnimationWallet.hpp
@@ -43,6 +43,7 @@ class AnimationWallet
         void replace_weight(int new_weight, int old_weight);
         void replace_min_max_level(int new_min_level, int new_max_level);
         void replace_min_max_butthurt(int new_min_butthurt, int new_max_butthurt);
+        void set_active(bool active);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -320,6 +320,7 @@ int main(int argc, char* argv[])
 
                     // popup modal for animation preview
                     bool not_used_popup_modal_preview = true;
+                    bool active_frames = animations_wallet->animations.at(current_anim)->active;
                     if(ImGui::BeginPopupModal(animations_wallet->animations.at(current_anim)->anim_name.c_str(), &not_used_popup_modal_preview, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar))
                     {
                         ImGui::Image((void*)(intptr_t)animations_wallet->animations.at(current_anim)->get_frame(), ImVec2(image_width*7.f, image_height*7.f));
@@ -353,7 +354,14 @@ int main(int argc, char* argv[])
                             }
                         }
                         ImGui::SameLine();
-                        ImGui::Text("Frame %d/%d", animations_wallet->animations.at(current_anim)->get_current_frame_number() + 1, animations_wallet->animations.at(current_anim)->get_total_frames_files());
+                        ImGui::Text("Frame %03d/%03d", animations_wallet->animations.at(current_anim)->get_current_frame_number() + 1, animations_wallet->animations.at(current_anim)->get_total_frames_number());
+                        ImGui::SameLine();
+                        if(ImGui::Checkbox("Active frames", &active_frames)) {
+                            if (active_frames)
+                                animations_wallet->animations.at(current_anim)->active = true;
+                            else
+                                animations_wallet->animations.at(current_anim)->active = false;
+                        }
                         ImGui::Separator();
                         // level sliders
                         ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.385f);
@@ -517,10 +525,20 @@ int main(int argc, char* argv[])
                 ImGui::MenuItem("Change level...");
                 if(ImGui::IsItemClicked())
                     ImGui::OpenPopup("Change level");
-                    
+
                 ImGui::MenuItem("Change butthurt...");
                 if(ImGui::IsItemClicked())
                     ImGui::OpenPopup("Change butthurt");
+                ImGui::MenuItem("Show only passive frames...");
+                if(ImGui::IsItemClicked()) {
+                    animations_wallet->set_active(false);
+                    notifications.add_notification(NOTIF_SUCCESS, "Success", "Show only passive frames for every animations.");
+                }
+                ImGui::MenuItem("Show active frames...");
+                if(ImGui::IsItemClicked()) {
+                    animations_wallet->set_active(true);
+                    notifications.add_notification(NOTIF_SUCCESS, "Success", "Show active frames for every animations.");
+                }
 
                 bool change_weight_popup = true;
                 ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(30, 20));


### PR DESCRIPTION
Hello,

Another contribution to support passive/active frames. By default animations are displayed only with passive frames. 
Active frames can be enabled (or disabled) in the animation popup via the added checkbox, or in the Tools menu to enable/disable active frames globally for all animations.

Here is major changes of this PR:
- Add `passive_frames` & `active_frames` Animation properties (uint). These properties store values from the meta.txt
- Add `active` Animation property to store the animation state, updated from the UI.
- Remove `total_frames_number` Animation property (unused).
- Use the `Animation::get_total_frames_number` function to return frames number based on the animation state (`active` property) instead of returning the `total_frames_number` property value.
- Update `Animation::next_frame` function to return the next frame depending of the animation state (`active` property).
- Create `AnimationWallet::set_active` function tu update state for every animations.
- UI: Add Checkbox in animation popup to update animation state.
- UI: Add MenuItems in Tools menu to change every animations states.